### PR TITLE
cloud-native-poc-zookeeper to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   version: 0.0.22
 - name: cloud-native-poc-zookeeper
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote cloud-native-poc-zookeeper to version 0.0.9