### PR TITLE
cloud-native-poc-kafka to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.7
 - name: cloud-native-poc-kafka
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.5
+  version: 0.0.6
 - name: cloud-native-poc-pdf
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.25


### PR DESCRIPTION
Promote cloud-native-poc-kafka to version 0.0.6